### PR TITLE
Update package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>message_generation</depend>
+  <depend>libopencv-dev</depend>
 
   <export>
   </export>


### PR DESCRIPTION
In https://github.com/kazuki0824/hdl_global_localization/blob/1f31f1c8a036e97ca8e81a76970f7dba30a7c805/CMakeLists.txt#L14, OpenCV is used. This PR adds `libopencv-dev` to package.xml so that rosdep can install all the dependencies comprehensively.