### PR TITLE
Dereference pointer to support more recent PCL

### DIFF
--- a/src/hdl_global_localization/engines/global_localization_bbs.cpp
+++ b/src/hdl_global_localization/engines/global_localization_bbs.cpp
@@ -46,7 +46,7 @@ void GlobalLocalizationBBS::set_global_map(pcl::PointCloud<pcl::PointXYZ>::Const
 
   auto map_3d = unslice(map_2d);
   map_3d->header.frame_id = "map";
-  map_slice_pub.publish(map_3d);
+  map_slice_pub.publish(*map_3d);
   gridmap_pub.publish(bbs->gridmap()->to_rosmsg());
 }
 
@@ -73,7 +73,7 @@ GlobalLocalizationResults GlobalLocalizationBBS::query(pcl::PointCloud<pcl::Poin
   if (scan_slice_pub.getNumSubscribers()) {
     auto scan_3d = unslice(scan_2d);
     scan_3d->header = cloud->header;
-    scan_slice_pub.publish(scan_3d);
+    scan_slice_pub.publish(*scan_3d);
   }
 
   Eigen::Isometry3f trans_3d = Eigen::Isometry3f::Identity();

--- a/src/hdl_global_localization_test.cpp
+++ b/src/hdl_global_localization_test.cpp
@@ -41,7 +41,7 @@ public:
     }
 
     cloud->header.frame_id = "map";
-    globalmap_pub.publish(cloud);
+    globalmap_pub.publish(*cloud);
   }
 
   void points_callback(sensor_msgs::PointCloud2ConstPtr cloud_msg) {
@@ -71,7 +71,7 @@ public:
     pcl::transformPointCloud(*cloud, *transformed, transformation);
     transformed->header.frame_id = "map";
 
-    points_pub.publish(transformed);
+    points_pub.publish(*transformed);
   }
 
 private:


### PR DESCRIPTION
PCL has changed from using `boost::shared_ptr` to `std::shared_ptr` since release 1.11. Compiling the package as is with a more recent PCL version will lead to compilation error since [publishers](https://github.com/ros-perception/perception_pcl/blob/melodic-devel/pcl_ros/include/pcl_ros/publisher.h) from `pcl_ros` only supports `boost::shared_ptr`. Dereferencing the point cloud pointer here will solve the problem